### PR TITLE
Init

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,4 @@
-name = "FYW"
+name = "FixYourWorkaround"
 uuid = "f47576e5-af05-5f64-9973-822c23b8e01f"
 version = "0.1.0"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,13 @@
+name = "FYW"
+uuid = "f47576e5-af05-5f64-9973-822c23b8e01f"
+version = "0.1.0"
+
+[deps]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+## FYW.jl (Fix Your Workaround)
+
+Have you ever created a work around because of a specific dependency version?
+This package is a test utility to ensure you remember to fix your workaround after support for it has been dropped.
+
+Whenever you create a workaround and plan to remove it after you drop version support for a package create a new test like so:
+
+```julia
+using FYW
+
+@test test_package_version("Package", "Version")
+```
+
+In the future when you remove the version from the `compat` section of your Project.toml this test will fail and remind you to remove your workaround.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## FYW.jl (Fix Your Workaround)
+## Fix Your Workaround.jl
 
 Have you ever created a work around because of a specific dependency version?
 This package is a test utility to ensure you remember to fix your workaround after support for it has been dropped.
@@ -6,7 +6,7 @@ This package is a test utility to ensure you remember to fix your workaround aft
 Whenever you create a workaround and plan to remove it after you drop version support for a package create a new test like so:
 
 ```julia
-using FYW
+using FixYourWorkaround
 
 @test test_package_version("Package", "Version")
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Whenever you create a workaround and plan to remove it after you drop version su
 ```julia
 using FixYourWorkaround
 
-@test test_package_version("Package", "Version")
+@test package_compatible("Package", "Version")
 ```
 
 In the future when you remove the version from the `compat` section of your Project.toml this test will fail and remind you to remove your workaround.

--- a/src/FYW.jl
+++ b/src/FYW.jl
@@ -1,0 +1,70 @@
+module FYW
+
+using Pkg
+using Pkg.Types: VersionSpec, semver_spec
+using Test
+
+export test_package_version
+export CompatNotFound, PackageNotInCompat, VersionNotCompatible
+
+struct CompatNotFound <: Exception
+    message::String
+end
+show(io::IO, e::CompatNotFound) = println(io, e.message)
+
+struct PackageNotInCompat <: Exception
+    message::String
+end
+show(io::IO, e::PackageNotInCompat) = println(io, e.message)
+
+struct VersionNotCompatible <: Exception
+    message::String
+end
+show(io::IO, e::VersionNotCompatible) = println(io, e.message)
+
+"""
+    test_package_version(package_name::String, version::String)
+
+Check to see if package_name@version is inbounds with the compat section in your Project.toml
+
+# Arguments
+- `package_name::String`: Name of the package
+- `version::String`: Package version to check being inbounds
+
+# Keywords
+- `toml_path::String`: Path to the Project.toml file
+
+# Returns
+- `Bool`: If the version is in the compat versions
+
+# Throws
+- `PackageNotInCompat`: package_name was not found in the compat section
+- `CompatNotFound`: Compat section not found in the Project.toml
+- `VersionOutsideSpec`: Version is no longer inbounds of the compat versions
+"""
+function test_package_version(package_name::String, version::String; toml_path=joinpath(@__DIR__, "..", "Project.toml"))
+    version = VersionSpec(version)
+    toml = Pkg.TOML.parsefile(toml_path)
+
+    if haskey(toml, "compat")
+        if haskey(toml["compat"], package_name)
+            compat_version = semver_spec(toml["compat"][package_name])
+
+            if !isempty(intersect(version, compat_version))
+                return true
+            else
+                throw(VersionNotCompatible("$package_name@$version is not support"))
+            end
+        else
+            throw(PackageNotInCompat("$package_name not found in compat section"))
+        end
+    else
+        throw(CompatNotFound("Compat section not found in Project.toml"))
+    end
+end
+
+test_package_version(package_name::String, version::Int64; kwargs...) = test_package_version(package_name, string(version); kwargs...)
+test_package_version(package_name::String, version::Float64; kwargs...) = test_package_version(package_name, string(version); kwargs...)
+test_package_version(package_name::String, version::VersionNumber; kwargs...) = test_package_version(package_name, string(version); kwargs...)
+
+end  # module

--- a/src/FYW.jl
+++ b/src/FYW.jl
@@ -1,4 +1,4 @@
-module FYW
+module FixYourWorkaround
 
 using Pkg
 using Pkg.Types: VersionSpec, semver_spec

--- a/src/FixYourWorkaround.jl
+++ b/src/FixYourWorkaround.jl
@@ -4,7 +4,7 @@ using Pkg
 using Pkg.Types: VersionSpec, semver_spec
 using Test
 
-export test_package_version
+export package_compatible
 export CompatNotFound, PackageNotInCompat, VersionNotCompatible
 
 struct CompatNotFound <: Exception
@@ -23,7 +23,7 @@ end
 show(io::IO, e::VersionNotCompatible) = println(io, e.message)
 
 """
-    test_package_version(package_name::String, version::String)
+    package_compatible(package_name::String, version::String)
 
 Check to see if package_name@version is inbounds with the compat section in your Project.toml
 
@@ -42,7 +42,7 @@ Check to see if package_name@version is inbounds with the compat section in your
 - `CompatNotFound`: Compat section not found in the Project.toml
 - `VersionOutsideSpec`: Version is no longer inbounds of the compat versions
 """
-function test_package_version(package_name::String, version::String; toml_path=joinpath(@__DIR__, "..", "Project.toml"))
+function package_compatible(package_name::String, version::String; toml_path=joinpath(@__DIR__, "..", "Project.toml"))
     version = VersionSpec(version)
     toml = Pkg.TOML.parsefile(toml_path)
 
@@ -61,10 +61,12 @@ function test_package_version(package_name::String, version::String; toml_path=j
     else
         throw(CompatNotFound("Compat section not found in Project.toml"))
     end
+
+    return false
 end
 
-test_package_version(package_name::String, version::Int64; kwargs...) = test_package_version(package_name, string(version); kwargs...)
-test_package_version(package_name::String, version::Float64; kwargs...) = test_package_version(package_name, string(version); kwargs...)
-test_package_version(package_name::String, version::VersionNumber; kwargs...) = test_package_version(package_name, string(version); kwargs...)
+package_compatible(package_name::String, version::Int64; kwargs...) = package_compatible(package_name, string(version); kwargs...)
+package_compatible(package_name::String, version::Float64; kwargs...) = package_compatible(package_name, string(version); kwargs...)
+package_compatible(package_name::String, version::VersionNumber; kwargs...) = package_compatible(package_name, string(version); kwargs...)
 
 end  # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,13 +9,13 @@ toml_path = joinpath(dir, "Project.toml")
     @testset "CompatNotFound" begin
         write(toml_path, "")
 
-        @test_throws CompatNotFound test_package_version(package_name, "0.0"; toml_path=toml_path)
+        @test_throws CompatNotFound package_compatible(package_name, "0.0"; toml_path=toml_path)
     end
 
     @testset "PackageNotInCompat" begin
         write(toml_path, "[compat]")
 
-        @test_throws PackageNotInCompat test_package_version(package_name, "0.0"; toml_path=toml_path)
+        @test_throws PackageNotInCompat package_compatible(package_name, "0.0"; toml_path=toml_path)
     end 
 end
 
@@ -28,7 +28,7 @@ end
         """
     )
 
-    @test_throws VersionNotCompatible test_package_version(package_name, "0.0"; toml_path=toml_path)
+    @test_throws VersionNotCompatible package_compatible(package_name, "0.0"; toml_path=toml_path)
 end
 
 @testset "Package in Versions" begin
@@ -40,7 +40,7 @@ end
         """
     )
 
-    @test test_package_version(package_name, "1.1"; toml_path=toml_path)
+    @test package_compatible(package_name, "1.1"; toml_path=toml_path)
 end
 
 @testset "Version::Int64" begin
@@ -52,7 +52,7 @@ end
         """
     )
 
-    @test test_package_version(package_name, 1; toml_path=toml_path)
+    @test package_compatible(package_name, 1; toml_path=toml_path)
 end
 
 @testset "Version::Float64" begin
@@ -64,7 +64,7 @@ end
         """
     )
 
-    @test test_package_version(package_name, 1.0; toml_path=toml_path)
+    @test package_compatible(package_name, 1.0; toml_path=toml_path)
 end
 
 @testset "Version::VersionNumber" begin
@@ -76,5 +76,5 @@ end
         """
     )
 
-    @test test_package_version(package_name, v"1"; toml_path=toml_path)
+    @test package_compatible(package_name, v"1"; toml_path=toml_path)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using FYW
+using FixYourWorkaround
 using Test
 
 package_name = "package"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,80 @@
+using FYW
+using Test
+
+package_name = "package"
+dir = mktempdir()
+toml_path = joinpath(dir, "Project.toml")
+
+@testset "Exceptions" begin
+    @testset "CompatNotFound" begin
+        write(toml_path, "")
+
+        @test_throws CompatNotFound test_package_version(package_name, "0.0"; toml_path=toml_path)
+    end
+
+    @testset "PackageNotInCompat" begin
+        write(toml_path, "[compat]")
+
+        @test_throws PackageNotInCompat test_package_version(package_name, "0.0"; toml_path=toml_path)
+    end 
+end
+
+@testset "Package outside of Versions" begin
+    write(
+        toml_path,
+        """
+        [compat]
+        $package_name = "1"
+        """
+    )
+
+    @test_throws VersionNotCompatible test_package_version(package_name, "0.0"; toml_path=toml_path)
+end
+
+@testset "Package in Versions" begin
+    write(
+        toml_path,
+        """
+        [compat]
+        $package_name = "1"
+        """
+    )
+
+    @test test_package_version(package_name, "1.1"; toml_path=toml_path)
+end
+
+@testset "Version::Int64" begin
+    write(
+        toml_path,
+        """
+        [compat]
+        $package_name = "1"
+        """
+    )
+
+    @test test_package_version(package_name, 1; toml_path=toml_path)
+end
+
+@testset "Version::Float64" begin
+    write(
+        toml_path,
+        """
+        [compat]
+        $package_name = "1"
+        """
+    )
+
+    @test test_package_version(package_name, 1.0; toml_path=toml_path)
+end
+
+@testset "Version::VersionNumber" begin
+    write(
+        toml_path,
+        """
+        [compat]
+        $package_name = "1"
+        """
+    )
+
+    @test test_package_version(package_name, v"1"; toml_path=toml_path)
+end


### PR DESCRIPTION
## Overview
This package was created to remind users to fix their version specific dependency workarounds. If for example you needed to create a workaround to support `DataFrames@0.21` you would then add a new test like:

```
# Git Issue #123
@test test_package_version("DataFrames", "0.21")
```

Then when you remove support for `DataFrames@0.21`, the test will fail, reminding you to remove your workaround so the code doesn't live endlessly.